### PR TITLE
Run as non-root by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,10 @@ RUN yum -y --setopt=tsflags=nodocs update && \
     rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY && \
     yum -y install opennms-sentinel && \
     yum clean all && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/yum && \
+    chown -R sentinel:sentinel /opt/sentinel
+
+USER sentinel
 
 COPY ./entrypoint.sh /
 


### PR DESCRIPTION
Sentinel was designed to run as non-root by default. For this reason, there is no need to force the docker container to run the karaf container as root by default.

This small change makes sure to use the default sentinel user as the owner of the process to run sentinel as non-root.