### PR TITLE
Replacing features/sentinel with develop.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opennms/openjdk:latest
 
-ARG SENTINEL_VERSION=branches-features-sentinel
+ARG SENTINEL_VERSION=develop
 
 ENV SENTINEL_HOME=/opt/sentinel
 


### PR DESCRIPTION
All the sentinel code has been merged to develop, so we should use that
branch as the base for this docker image.