### PR TITLE
Required changes to run Sentinel on OpenShift.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,13 @@ RUN yum -y --setopt=tsflags=nodocs update && \
     yum -y install opennms-sentinel && \
     yum clean all && \
     rm -rf /var/cache/yum && \
-    chown -R sentinel:sentinel /opt/sentinel
+    chown -R sentinel:sentinel /opt/sentinel && \
+    chgrp -R 0 /opt/sentinel && \
+    chmod -R g=u /opt/sentinel
 
-USER sentinel
+USER 999
 
 COPY ./docker-entrypoint.sh /
-
-VOLUME [ "/opt/sentinel/deploy", "/opt/sentinel/etc", "/opt/sentinel/data" ]
 
 LABEL license="AGPLv3" \
       org.opennms.horizon.version="${SENTINEL_VERSION}" \
@@ -43,12 +43,11 @@ LABEL license="AGPLv3" \
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
-CMD [ "-h" ]
+CMD [ "-f" ]
 
 ##------------------------------------------------------------------------------
 ## EXPOSED PORTS
 ##------------------------------------------------------------------------------
 ## -- Sentinel Karaf Debug 5005/TCP
 ## -- Sentinel KARAF SSH   8301/TCP
-EXPOSE 5005
 EXPOSE 8301

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -105,7 +105,7 @@ applyOverlayConfig() {
 
 start() {
     cd ${SENTINEL_HOME}/bin
-    ./karaf server ${SENTINEL_DEBUG}
+    exec ./karaf server ${SENTINEL_DEBUG}
 }
 
 # Evaluate arguments for build script.


### PR DESCRIPTION
As described [here](https://docs.okd.io/latest/creating_images/guidelines.html#openshift-specific-guidelines), there are multiple changes required on the `Dockerfile`, in order to run Docker images on OpenShift.

The core changes are:

1) Image must run as non-root.
2) Image must run with an arbitrary UID, which requires permission on the runtime folders/files so OpenShift can read/write files with this arbitrary UID.
3) The `USER` entry on the `Dockerfile` should use the numeric UID, not the name of the user.
4) Volumes should only be declared when they are mandatory, not when they are optional.
5) The default command should point to a running state by default, to avoid redeploy the image once created. This is a special use case when the OpenShift UI is used to deploy the application.
6) Make sure that the main process runs at PID 1, and it properly process SIGTERM for graceful shutdowns.