### PR TITLE
Applying changes required to run within OpenShift.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM opennms/openjdk:latest
 
-ARG SENTINEL_VERSION="develop"
+ARG SENTINEL_VERSION=develop
+ARG MIRROR_HOST=yum.opennms.org
 
 ENV SENTINEL_HOME=/opt/sentinel
 
@@ -23,8 +24,8 @@ ENV POSTGRES_PASSWORD=
 ENV POSTGRES_DB=opennms
 
 RUN yum -y --setopt=tsflags=nodocs update && \
-    rpm -Uvh http://yum.opennms.org/repofiles/opennms-repo-${SENTINEL_VERSION/\//-}-rhel7.noarch.rpm && \
-    rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY && \
+    rpm -Uvh https://${MIRROR_HOST}/repofiles/opennms-repo-${SENTINEL_VERSION/\//-}-rhel7.noarch.rpm && \
+    rpm --import https://${MIRROR_HOST}/OPENNMS-GPG-KEY && \
     yum -y install opennms-sentinel && \
     yum clean all && \
     rm -rf /var/cache/yum && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,9 @@
 # Cause false/positives
 # shellcheck disable=SC2086
 
+# To avoid issues with OpenShift
+umask 002
+
 SENTINEL_OVERLAY_ETC="/opt/sentinel-etc-overlay"
 SENTINEL_OVERLAY="/opt/sentinel-overlay"
 
@@ -123,6 +126,7 @@ applyKarafDebugLogging() {
 }
 
 start() {
+    export KARAF_EXEC="exec"
     cd ${SENTINEL_HOME}/bin
     exec ./karaf server ${SENTINEL_DEBUG}
 }


### PR DESCRIPTION
- Additional infrastructure changes were added to be able to build
  images for any OpenNMS branch.
- Additional change added to make sure that the java process will
  inherit the PID 1, so Karaf will gracefully shutdown when receiving
  a SIGTERM.