### PR TITLE
OCE-46: Allow overlay for any sentinel files so that we can overlay kar files into the deploy directory

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -103,7 +103,7 @@ applyOverlayConfig() {
     echo "No custom config found in ${SENTINEL_OVERLAY_ETC}. Use default configuration."
   fi
   # Overlay for all of the sentinel dir
-  if [ -d "$SENTINEL_OVERLAY" -a -n "$(ls -A ${SENTINEL_OVERLAY})" ]; then
+  if [ -d "$SENTINEL_OVERLAY" ] && [ -n "$(ls -A ${SENTINEL_OVERLAY})" ]; then
     echo "Apply custom configuration from ${SENTINEL_OVERLAY}."
     cp -r ${SENTINEL_OVERLAY}/* ${SENTINEL_HOME}/ || exit ${E_INIT_CONFIG}
   else


### PR DESCRIPTION
This PR brings over some changes from the `release-oce` branch into the master branch so that the OCE kar file can be deployed easily into the vanilla sentinel container.

This is being done for the end to end tests.

Jira: https://issues.opennms.org/browse/OCE-46