### PR TITLE
OCE-46: Allow overlay for any sentinel files so that we can overlay kar files into the deploy directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Generate version number for Docker tag
           command: |
             DOCKERHUB_TAG=${CIRCLE_BRANCH#release/}
-            DOCKERHUB_TAG=${DOCKERHUB_TAG/\//-}
+            DOCKERHUB_TAG=${DOCKERHUB_TAG//\//-}
             echo ${DOCKERHUB_TAG} > dockertag
             echo ${DOCKERHUB_TAG}
       - run:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -103,7 +103,7 @@ applyOverlayConfig() {
     echo "No custom config found in ${SENTINEL_OVERLAY_ETC}. Use default configuration."
   fi
   # Overlay for all of the sentinel dir
-  if [ -d "$SENTINEL_OVERLAY" -a -n "$(ls -A ${SENTINEL_OVERLAY})" ]; then
+  if [ -d "$SENTINEL_OVERLAY" ] && [ -n "$(ls -A ${SENTINEL_OVERLAY})" ]; then
     echo "Apply custom configuration from ${SENTINEL_OVERLAY}."
     cp -r ${SENTINEL_OVERLAY}/* ${SENTINEL_HOME}/ || exit ${E_INIT_CONFIG}
   else


### PR DESCRIPTION
Bring the overlay copying from master to release/24.0.0-rc branch. Picked from PR https://github.com/opennms-forge/docker-sentinel/pull/9